### PR TITLE
fix: hide comment section if comments are set to disabled

### DIFF
--- a/client/containers/App/app.scss
+++ b/client/containers/App/app.scss
@@ -9,6 +9,25 @@
 		outline: none;
 		flex-grow: 1;
 	}
+	/* Let the pub page fill the viewport, so its grey bottom section reaches the footer instead
+	   of leaving a white gap when the pub is shorter than the screen. Every link in the chain
+	   has to be a column flex container for the next one to grow into it:
+
+	     #app > #main-content > #pub-container > .pub-document-component > .pub-bottom-component
+
+	   .pub-document-component (pubDocument.scss) and .pub-bottom-component (pubBottom.scss)
+	   already declare `flex-grow: 1`; both were inert because #main-content and #pub-container
+	   are plain blocks. These rules connect them. Skipped on the dashboard, which has its own
+	   padded #main-content layout and no growing root. */
+	&:not(.dashboard) #main-content {
+		display: flex;
+		flex-direction: column;
+		#pub-container {
+			display: flex;
+			flex-direction: column;
+			flex-grow: 1;
+		}
+	}
 	.duqduq-warning {
 		position: fixed;
 		right: 10px;

--- a/client/containers/App/app.scss
+++ b/client/containers/App/app.scss
@@ -15,9 +15,9 @@
 
 	     #app > #main-content > #pub-container > .pub-document-component > .pub-bottom-component
 
-	   .pub-document-component (pubDocument.scss) and .pub-bottom-component (pubBottom.scss)
-	   already declare `flex-grow: 1`; both were inert because #main-content and #pub-container
-	   are plain blocks. These rules connect them. Skipped on the dashboard, which has its own
+	   .pub-document-component (pubDocument.scss) declares `flex-grow: 1` and is a column flex container;
+	   .pub-grid absorbs leftover space while .pub-bottom-component (pubBottom.scss) stays at content height.
+	   These rules connect that chain by making #main-content and #pub-container flex columns. Skipped on the dashboard, which has its own
 	   padded #main-content layout and no growing root. */
 	&:not(.dashboard) #main-content {
 		display: flex;

--- a/client/containers/Pub/PubDocument/PubBottom/pubBottom.scss
+++ b/client/containers/Pub/PubDocument/PubBottom/pubBottom.scss
@@ -2,7 +2,8 @@
 
 .pub-bottom-component {
 	background: #f6f4f4;
-	flex-grow: 1;
+	/* Stay at content height — .pub-grid takes the leftover viewport space instead. */
+	flex-grow: 0;
 	overflow: hidden;
 	padding: 2em 0em;
 	margin-top: 2em;

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -39,7 +39,7 @@ const PubDocument = () => {
 	const { isViewingHistory } = historyData;
 	const { communityData, scopeData, featureFlags } = usePageContext();
 	const pubEdgeDisplay = useFacetsQuery((F) => F.PubEdgeDisplay);
-	const { canEdit, canEditDraft } = scopeData.activePermissions;
+	const { canEdit, canEditDraft, discussionCreationAccess } = scopeData.activePermissions;
 	const { isReviewingPub } = pubData;
 	const mainContentRef = useRef<null | HTMLDivElement>(null);
 	const sideContentRef = useRef(null);
@@ -50,6 +50,13 @@ const PubDocument = () => {
 	usePubHrefs({ enabled: !isReadOnly });
 
 	const showPubFileImport = (canEdit || canEditDraft) && !isReadOnly;
+
+	/* When discussions are disabled and there's nothing to read, the Comments section is just an */
+	/* empty box with controls that do nothing. Discussions arrive already sanitized (spam, banned */
+	/* authors and draft-vs-release visibility are filtered server-side), so an empty list here */
+	/* means there is nothing this reader is allowed to see. */
+	const showDiscussions =
+		discussionCreationAccess !== 'disabled' || !!pubData.discussions?.length;
 
 	if (hidePubBody) {
 		return null;
@@ -125,6 +132,7 @@ const PubDocument = () => {
 			</div>
 			<PubBottom
 				pubData={pubData}
+				showDiscussions={showDiscussions}
 				updateLocalData={updateLocalData}
 				sideContentRef={sideContentRef}
 				mainContentRef={mainContentRef}

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -39,7 +39,7 @@ const PubDocument = () => {
 	const { isViewingHistory } = historyData;
 	const { communityData, scopeData, featureFlags } = usePageContext();
 	const pubEdgeDisplay = useFacetsQuery((F) => F.PubEdgeDisplay);
-	const { canEdit, canEditDraft, discussionCreationAccess } = scopeData.activePermissions;
+	const { canEdit, canEditDraft, canCreateDiscussions } = scopeData.activePermissions;
 	const { isReviewingPub } = pubData;
 	const mainContentRef = useRef<null | HTMLDivElement>(null);
 	const sideContentRef = useRef(null);
@@ -51,12 +51,13 @@ const PubDocument = () => {
 
 	const showPubFileImport = (canEdit || canEditDraft) && !isReadOnly;
 
-	/* When discussions are disabled and there's nothing to read, the Comments section is just an */
-	/* empty box with controls that do nothing. Discussions arrive already sanitized (spam, banned */
-	/* authors and draft-vs-release visibility are filtered server-side), so an empty list here */
-	/* means there is nothing this reader is allowed to see. */
-	const showDiscussions =
-		discussionCreationAccess !== 'disabled' || !!pubData.discussions?.length;
+	/* Only show the Comments section if there's something to read, or this reader can actually */
+	/* post. Otherwise it's an empty box with sort/filter controls that do nothing — which is what */
+	/* a logged-out visitor saw on a Community that limits commenting to members and contributors, */
+	/* or that disabled it outright. Discussions arrive already sanitized (spam, banned authors */
+	/* and draft-vs-release visibility are filtered server-side), so an empty list here means */
+	/* there is nothing this reader is allowed to see. */
+	const showDiscussions = canCreateDiscussions || !!pubData.discussions?.length;
 
 	if (hidePubBody) {
 		return null;

--- a/client/containers/Pub/PubDocument/pubDocument.scss
+++ b/client/containers/Pub/PubDocument/pubDocument.scss
@@ -5,6 +5,13 @@
 	flex-direction: column;
 	flex-grow: 1;
 
+	/* Absorb any leftover viewport height into the body rather than the bottom section, so a pub
+	   shorter than the screen keeps a compact License / Comments strip sitting on the footer
+	   instead of stretching it into a tall grey band. */
+	.pub-grid {
+		flex-grow: 1;
+	}
+
 	.top-pub-edges {
 		margin-top: 30px;
 		margin-bottom: 30px;

--- a/server/publicPermissions/model.ts
+++ b/server/publicPermissions/model.ts
@@ -33,7 +33,7 @@ export class PublicPermissions extends Model<
 	declare canCreateDiscussions: boolean | null;
 
 	@Default('public')
-	@Column(DataType.ENUM('public', 'contributors', 'members', 'disabled'))
+	@Column(DataType.ENUM('public', 'contributors-members', 'disabled'))
 	declare discussionCreationAccess: CreationOptional<DiscussionCreationAccess>;
 
 	@Column(DataType.BOOLEAN)

--- a/server/publicPermissions/model.ts
+++ b/server/publicPermissions/model.ts
@@ -12,6 +12,8 @@ import {
 	Table,
 } from 'sequelize-typescript';
 
+import { discussionCreationAccessValues } from 'types/community';
+
 import { Pub } from '../models';
 
 @Table
@@ -33,7 +35,7 @@ export class PublicPermissions extends Model<
 	declare canCreateDiscussions: boolean | null;
 
 	@Default('public')
-	@Column(DataType.ENUM('public', 'contributors-members', 'disabled'))
+	@Column(DataType.ENUM(...discussionCreationAccessValues))
 	declare discussionCreationAccess: CreationOptional<DiscussionCreationAccess>;
 
 	@Column(DataType.BOOLEAN)

--- a/types/community.ts
+++ b/types/community.ts
@@ -15,4 +15,9 @@ export type CommunityHeaderLink = {
 
 export type Community = SerializedModel<CommunityModel>;
 
-export type DiscussionCreationAccess = 'public' | 'contributors-members' | 'disabled';
+export const discussionCreationAccessValues = [
+	'public',
+	'contributors-members',
+	'disabled',
+] as const;
+export type DiscussionCreationAccess = (typeof discussionCreationAccessValues)[number];

--- a/utils/api/contracts/publicPermissions.ts
+++ b/utils/api/contracts/publicPermissions.ts
@@ -3,6 +3,8 @@ import type { AppRouter } from '@ts-rest/core';
 import { extendZodWithOpenApi } from '@anatine/zod-openapi';
 import { z } from 'zod';
 
+import { discussionCreationAccessValues } from 'types/community';
+
 extendZodWithOpenApi(z);
 
 export const publicPermissionsRouter = {
@@ -11,7 +13,7 @@ export const publicPermissionsRouter = {
 		method: 'PUT',
 		summary: 'Update who is able to create new discussions',
 		body: z.object({
-			discussionCreationAccess: z.enum(['public', 'contributors-members', 'disabled']),
+			discussionCreationAccess: z.enum(discussionCreationAccessValues),
 		}),
 		responses: {
 			200: z.object({ success: z.boolean() }),

--- a/utils/api/contracts/publicPermissions.ts
+++ b/utils/api/contracts/publicPermissions.ts
@@ -11,7 +11,7 @@ export const publicPermissionsRouter = {
 		method: 'PUT',
 		summary: 'Update who is able to create new discussions',
 		body: z.object({
-			discussionCreationAccess: z.enum(['public', 'contributors', 'members', 'disabled']),
+			discussionCreationAccess: z.enum(['public', 'contributors-members', 'disabled']),
 		}),
 		responses: {
 			200: z.object({ success: z.boolean() }),

--- a/utils/api/schemas/community.ts
+++ b/utils/api/schemas/community.ts
@@ -2,6 +2,8 @@ import type * as types from 'types';
 
 import { z } from 'zod';
 
+import { discussionCreationAccessValues } from 'types/community';
+
 import { baseSchema } from '../utils/baseSchema';
 import { analyticsSettingsSchema } from './analyticsSettings';
 
@@ -138,5 +140,5 @@ export const communityUpdateSchema = communitySchema
 	})
 	.extend({
 		communityId: communitySchema.shape.id,
-		discussionCreationAccess: z.enum(['public', 'contributors-members', 'disabled']).optional(),
+		discussionCreationAccess: z.enum(discussionCreationAccessValues).optional(),
 	});


### PR DESCRIPTION
## Issue(s) Resolved

-

## Test Plan

## Screenshots (if applicable)

<img width="1198" height="1174" alt="image" src="https://github.com/user-attachments/assets/ad86a965-0529-4694-a03c-664702bf58b0" />

<img width="1185" height="1170" alt="image" src="https://github.com/user-attachments/assets/7c02bb27-5e61-430d-a808-832e158339f9" />


## Optional

### Notes/Context/Gotchas

### Supporting Docs
